### PR TITLE
Change gcc compiler from gcc-5 to default gcc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CC=gcc-5 -I. -DANDROID
+CC=gcc -I. -DANDROID
 AR=ar
 RM=rm
 ECHO=echo


### PR DESCRIPTION
Change the default compiler to gcc so the tools can be compiled with
the default gcc (4.9.2 on Debian)
